### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Put your changes here...
 
+## 1.0.2
+
+- Fixed a bug that could cause templates to be significantly altered by this preprocessor due to having been fully ingested by a DOM parser and then re-serialized back into a string. As of this version, only the custom elements that are progressively enhanced will be ingested by the DOM parser and re-serialized back into a string.
+- Fixed a bug that caused errors to print to the console if inline CSS existed in a scanned template.
+- Updated various dependencies.
+
 ## 1.0.1
 
 - Fixed a bug that prevented camelCase attribute names from replacing `${templateLiteral}` values for values in <template> markup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "progressively-enhance-web-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "progressively-enhance-web-components",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "js-beautify": "1.15.3",
+        "js-beautify": "1.15.4",
         "jsdom": "26.0.0"
       },
       "devDependencies": {
@@ -444,12 +444,12 @@
       "license": "ISC"
     },
     "node_modules/abbrev": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
-      "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3372,16 +3372,16 @@
       }
     },
     "node_modules/js-beautify": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.3.tgz",
-      "integrity": "sha512-rKKGuyTxGNlyN4EQKWzNndzXpi0bOl8Gl8YQAW1as/oMz0XhD6sHJO1hTvoBDOSzKuJb9WkwoAb34FfdkKMv2A==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
       "license": "MIT",
       "dependencies": {
         "config-chain": "^1.1.13",
         "editorconfig": "^1.0.4",
         "glob": "^10.4.2",
         "js-cookie": "^3.0.5",
-        "nopt": "^8.0.0"
+        "nopt": "^7.2.1"
       },
       "bin": {
         "css-beautify": "js/bin/css-beautify.js",
@@ -3787,18 +3787,18 @@
       "license": "MIT"
     },
     "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^2.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -5157,21 +5157,21 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.79",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.79.tgz",
-      "integrity": "sha512-wjlYwK8lC/WcywLWf3A7qbK07SexezXjTRVwuPWXHvcjD7MnpPS2RXY5rLO3g12a8CNc7Y7jQRQsV7XyuBZjig==",
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.82.tgz",
+      "integrity": "sha512-KCTjNL9F7j8MzxgfTgjT+v21oYH38OidFty7dH00maWANAI2IsLw2AnThtTJi9HKALHZKQQWnNebYheadacD+g==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.79"
+        "tldts-core": "^6.1.82"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.79",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.79.tgz",
-      "integrity": "sha512-HM+Ud/2oQuHt4I43Nvjc213Zji/z25NSH5OkJskJwHXNtYh9DTRlHMDFhms9dFMP7qyve/yVaXFIxmcJ7TdOjw==",
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
+      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -5188,9 +5188,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
-      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/progressively-enhance-web-components/graphs/contributors"
     }
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/rooseveltframework/progressively-enhance-web-components",
   "license": "CC-BY-4.0",
   "main": "progressively-enhance-web-components.js",
@@ -16,7 +16,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "js-beautify": "1.15.3",
+    "js-beautify": "1.15.4",
     "jsdom": "26.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -29,11 +29,11 @@ describe('progressively-enhance-web-components tests', function () {
     const filePath = path.join(sampleAppDir, 'mvc', '.preprocessed_views', 'pageWithForm.html')
     const fileContent = fs.readFileSync(filePath, 'utf8')
     assert(fileContent.includes(`<word-count text="Once upon a time... " elid="story">
-            <div>
-              <textarea rows="10" cols="50" name="story" id="story">Once upon a time... </textarea>
-              <span class="word-count"></span>
-            </div>
-            <p slot="description">Type your story in the box above!</p>
-          </word-count>`), 'Expected markup not found')
+  <div>
+    <textarea rows="10" cols="50" name="story" id="story">Once upon a time... </textarea>
+    <span class="word-count"></span>
+  </div>
+  <p slot="description">Type your story in the box above!</p>
+</word-count>`), 'Expected markup not found')
   })
 })


### PR DESCRIPTION
- Fixed a bug that could cause templates to be significantly altered by this preprocessor due to having been fully ingested by a DOM parser and then re-serialized back into a string. As of this version, only the custom elements that are progressively enhanced will be ingested by the DOM parser and re-serialized back into a string.
- Fixed a bug that caused errors to print to the console if inline CSS existed in a scanned template.
- Updated various dependencies.