### PR TITLE
1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Put your changes here...
 
+## 1.0.3
+
+- Fixed another bug that caused errors to print to the console if inline CSS existed in a scanned template.
+
 ## 1.0.2
 
 - Fixed a bug that could cause templates to be significantly altered by this preprocessor due to having been fully ingested by a DOM parser and then re-serialized back into a string. As of this version, only the custom elements that are progressively enhanced will be ingested by the DOM parser and re-serialized back into a string.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "progressively-enhance-web-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "progressively-enhance-web-components",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "CC-BY-4.0",
       "dependencies": {
         "js-beautify": "1.15.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/progressively-enhance-web-components/graphs/contributors"
     }
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/rooseveltframework/progressively-enhance-web-components",
   "license": "CC-BY-4.0",
   "main": "progressively-enhance-web-components.js",

--- a/progressively-enhance-web-components.js
+++ b/progressively-enhance-web-components.js
@@ -29,9 +29,10 @@ function isBinaryFile (filePath, bytesToCheck = 512) {
 
 // hack to get jsdom to shut up about invalid css
 const originalConsoleError = console.error
-console.error = (...args) => {
-  if (args?.[0]?.type !== 'css parsing') {
-    originalConsoleError(...args)
+const jsDomCssError = 'Error: Could not parse CSS stylesheet'
+console.error = (...params) => {
+  if (!params.find(p => p.toString().includes(jsDomCssError))) {
+    originalConsoleError(...params)
   }
 }
 


### PR DESCRIPTION
- Fixed another bug that caused errors to print to the console if inline CSS existed in a scanned template.